### PR TITLE
Update frontend for new backend API

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -16,7 +16,7 @@ interface PlayerData {
   level: number;
   experience: number;
   totalDamage: number;
-  coins: number;
+  tokenBalance: number;
   damage: number;
   attackCount: number;
   isOnline: boolean;

--- a/src/components/MonsterComponent.tsx
+++ b/src/components/MonsterComponent.tsx
@@ -11,12 +11,14 @@ import VoidSigilSpell from './spells/VoidSigilSpell';
 /* ---------- Types ---------- */
 interface Monster {
   id: string;
+  spawnId: string;
   name: string;
   image: string;
   maxHealth: number;
   currentHealth: number;
   level: number;
   createdAt: number;
+  healthPercentage?: number;
 }
 
 interface DamageEvent {

--- a/src/components/MonsterKillHistory.tsx
+++ b/src/components/MonsterKillHistory.tsx
@@ -12,13 +12,15 @@ interface PlayerDamage {
   walletAddress: string;
   damage: number;
   xpGained: number;
-  coinsEarned: number;
+  tokensEarned: number;
 }
 
 interface SpawnRecord {
   spawnId: string;
   templateName: string;
   level: number;
+  maxHealth?: number;
+  createdAt?: string;
   defeatedAt: string;
   damageByPlayer: PlayerDamage[];
 }

--- a/src/components/MonsterKillModal.tsx
+++ b/src/components/MonsterKillModal.tsx
@@ -8,7 +8,7 @@ interface PlayerDamage {
   walletAddress: string;
   damage: number;
   xpGained: number;
-  coinsEarned: number;
+  tokensEarned: number;
 }
 
 interface SpawnRecord {
@@ -50,7 +50,7 @@ const MonsterKillModal: FC<MonsterKillModalProps> = ({ spawn, onClose }) => {
           <div className="grid grid-cols-4 text-xs text-gray-400 font-semibold mb-1">
             <span>Player</span>
             <span className="text-right">DMG</span>
-            <span className="text-right">Coins</span>
+            <span className="text-right">Tokens</span>
             <span className="text-right">XP</span>
           </div>
           {spawn.damageByPlayer.map((p, idx) => (
@@ -60,7 +60,7 @@ const MonsterKillModal: FC<MonsterKillModalProps> = ({ spawn, onClose }) => {
             >
               <span className="truncate text-gray-200">{formatAddr(p.walletAddress)}</span>
               <span className="text-red-400 font-mono text-right">{p.damage}</span>
-              <span className="text-yellow-400 font-mono text-right">{p.coinsEarned}</span>
+              <span className="text-yellow-400 font-mono text-right">{p.tokensEarned}</span>
               <span className="text-green-400 font-mono text-right">{p.xpGained}</span>
             </div>
           ))}

--- a/src/components/PlayerStats.tsx
+++ b/src/components/PlayerStats.tsx
@@ -8,7 +8,7 @@ interface PlayerData {
   level: number;
   experience: number;
   totalDamage: number;
-  coins: number;
+  tokenBalance: number;
   damage: number;
   attackCount: number;
   isOnline: boolean;
@@ -98,9 +98,9 @@ const PlayerStats: FC<PlayerStatsProps> = ({ player }) => {
           </div>
 
           <div className="flex items-center justify-between">
-            <span className="text-gray-300 text-sm">Coins:</span>
+            <span className="text-gray-300 text-sm">Tokens:</span>
             <span className="text-yellow-400 font-bold">
-              {player.coins.toLocaleString()}
+              {player.tokenBalance.toLocaleString()}
             </span>
           </div>
 

--- a/src/lib/useSocket.ts
+++ b/src/lib/useSocket.ts
@@ -273,14 +273,21 @@ export const useSocket = () => {
             players[idx] = {
               ...players[idx],
               damage: players[idx].damage + response.damageEvent.damage,
+              totalDamage:
+                players[idx].totalDamage + response.damageEvent.damage,
+              attackCount: players[idx].attackCount + 1,
               level: response.attacker?.playerUpdate.level ?? players[idx].level,
-              isOnline: true
+              isOnline: true,
+              tokenBalance: players[idx].tokenBalance
             };
           } else {
             players.push({
               name: response.damageEvent.playerName,
               walletAddress: response.damageEvent.walletAddress,
               damage: response.damageEvent.damage,
+              totalDamage: response.damageEvent.damage,
+              attackCount: 1,
+              tokenBalance: 0,
               level: response.attacker?.playerUpdate.level ?? 1,
               isOnline: true
             });

--- a/src/lib/useSocket.ts
+++ b/src/lib/useSocket.ts
@@ -18,6 +18,7 @@ interface DamageEvent {
 
 interface Monster {
   id: string;
+  spawnId: string;
   name: string;
   /** Path to monster image */
   image: string;
@@ -25,6 +26,7 @@ interface Monster {
   currentHealth: number;
   level: number;
   createdAt: number;
+  healthPercentage: number;
 }
 
 interface Player {
@@ -33,6 +35,9 @@ interface Player {
   isOnline: boolean;
   level: number;
   walletAddress: string;
+  tokenBalance: number;
+  totalDamage: number;
+  attackCount: number;
 }
 
 interface PlayerStats {
@@ -41,7 +46,7 @@ interface PlayerStats {
   level: number;
   experience: number;
   totalDamage: number;
-  coins: number;
+  tokenBalance: number;
   damage: number;
   attackCount: number;
   isOnline: boolean;
@@ -61,11 +66,10 @@ interface AttackResponse {
     playerUpdate: {
       level: number;
       experience: number;
-      coins: number;
+      tokenBalance: number;
       totalDamage: number;
       damage: number;
     };
-    leveledUp: boolean;
   };
   damageEvent?: DamageEvent;
   monster?: Monster;
@@ -151,7 +155,7 @@ export const useSocket = () => {
         });
       }
 
-      setCurrentMonsterId(state.monster.id);
+      setCurrentMonsterId(state.monster.spawnId);
       const tally: Record<string, number> = {};
       state.damageEvents.forEach(ev => {
         tally[ev.walletAddress] = (tally[ev.walletAddress] || 0) + ev.damage;
@@ -289,7 +293,7 @@ export const useSocket = () => {
       // if the monster died, reset for the next one
       if (response.monsterKilled && response.newMonster) {
         setBossDamage({});
-        setCurrentMonsterId(response.newMonster.id);
+        setCurrentMonsterId(response.newMonster.spawnId);
         setDamageEvents([]);
         const monsterWithImage = {
           ...response.newMonster,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,17 +1,20 @@
 export interface Player {
-  id: string;
+  walletAddress: string;
   name: string;
-  damage: number;
+  level: number;
+  tokenBalance: number;
+  experience: number;
   totalDamage: number;
-  coins: number;
+  attackCount: number;
   isOnline: boolean;
-  attackCount?: number;
+  damage: number;
   joinedAt?: number;
   lastSeen?: number;
 }
 
 export interface Monster {
   id: string;
+  spawnId: string;
   name: string;
   /** Path to the monster image under `/public` */
   image: string;
@@ -19,6 +22,7 @@ export interface Monster {
   currentHealth: number;
   level: number;
   createdAt?: number;
+  healthPercentage?: number;
 }
 
 export interface DamageEvent {


### PR DESCRIPTION
## Summary
- adjust Monster and Player models
- sync socket and UI types with backend
- rename coins to tokens in stats and kill logs
- handle monster spawnId from API

## Testing
- `npm install` *(fails: interactive warnings but completes)*
- `npm run lint` *(prompts for setup and exits)*

------
https://chatgpt.com/codex/tasks/task_e_684b70bd515c8323b2321b91e4fceb8a