### PR TITLE
Add spell history display

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import MonsterDamageBoard from '@/components/MonsterDamageBoard';
 import TreasureBox from '@/components/TreasureBox';
 import MobileMenu from '@/components/MobileMenu';
 import MonsterKillHistory from '@/components/MonsterKillHistory';
+import SpellHistory from '@/components/SpellHistory';
 import Footer from '@/components/Footer';
 import { devLog } from '@/lib/devLog';
 import Image from 'next/image';
@@ -256,9 +257,10 @@ export default function Home() {
         <TreasureBox xp={lootXp} tokens={lootTokens} />
       </div>
 
-      {/* Kill history - desktop only */}
-      <div className="hidden md:block absolute top-20 right-4 z-40">
+      {/* Kill and Spell history - desktop only */}
+      <div className="hidden md:block absolute top-20 right-4 z-40 space-y-4">
         <MonsterKillHistory />
+        <SpellHistory />
       </div>
 
       {/* Desktop layout */}

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { FC, useState } from 'react';
-import { X, Menu, BarChart3, Users, Sword, PackageOpen, Skull } from 'lucide-react';
+import { X, Menu, BarChart3, Users, Sword, PackageOpen, Skull, Sparkles } from 'lucide-react';
 import PlayerStats from './PlayerStats';
 import Leaderboard from './Leaderboard';
 import MonsterDamageBoard from './MonsterDamageBoard';
 import TreasureBox from './TreasureBox';
 import MonsterKillHistory from './MonsterKillHistory';
+import SpellHistory from './SpellHistory';
 import Image from "next/image";
 
 
@@ -51,7 +52,7 @@ const MobileMenu: FC<MobileMenuProps> = ({
   tokens
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState<'stats' | 'leaderboard' | 'damage' | 'loot' | 'history'>('stats');
+  const [activeTab, setActiveTab] = useState<'stats' | 'leaderboard' | 'damage' | 'loot' | 'history' | 'spells'>('stats');
 
   const toggleMenu = () => setIsOpen(!isOpen);
 
@@ -61,6 +62,7 @@ const MobileMenu: FC<MobileMenuProps> = ({
     { id: 'damage' as const, label: 'Boss DMG', icon: Sword },
     { id: 'loot' as const, label: 'Loot', icon: PackageOpen },
     { id: 'history' as const, label: 'Kills', icon: Skull },
+    { id: 'spells' as const, label: 'Spells', icon: Sparkles },
   ];
 
   return (
@@ -156,6 +158,12 @@ const MobileMenu: FC<MobileMenuProps> = ({
           {activeTab === 'history' && (
             <div className="space-y-4">
               <MonsterKillHistory />
+            </div>
+          )}
+
+          {activeTab === 'spells' && (
+            <div className="space-y-4">
+              <SpellHistory />
             </div>
           )}
         </div>

--- a/src/components/SpellHistory.tsx
+++ b/src/components/SpellHistory.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { FC, useCallback, useEffect, useState } from 'react';
+import { Sparkles } from 'lucide-react';
+import { useSocket } from '@/lib/useSocket';
+
+const SOCKET_URL = process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3001';
+
+interface SpellMeta {
+  id: string;
+  name: string;
+  emoji: string;
+  cost: number;
+  description: string;
+}
+
+interface SpellRecord {
+  id: number;
+  spellId: string;
+  wallet: string;
+  spawnId: string;
+  createdAt: string;
+}
+
+interface SpellHistoryProps {
+  limit?: number;
+}
+
+const SpellHistory: FC<SpellHistoryProps> = ({ limit = 5 }) => {
+  const { socket } = useSocket();
+  const [history, setHistory] = useState<SpellRecord[]>([]);
+  const [spells, setSpells] = useState<Record<string, SpellMeta>>({});
+
+  const fetchSpells = useCallback(async () => {
+    try {
+      const res = await fetch(`${SOCKET_URL}/api/game/spells`);
+      if (res.ok) {
+        const data: SpellMeta[] = await res.json();
+        const map: Record<string, SpellMeta> = {};
+        data.forEach(s => {
+          map[s.id] = s;
+        });
+        setSpells(map);
+      }
+    } catch (err) {
+      console.error('Failed to fetch spells list', err);
+    }
+  }, []);
+
+  const fetchHistory = useCallback(async () => {
+    try {
+      const res = await fetch(`${SOCKET_URL}/api/game/spells/history?limit=${limit}`);
+      if (res.ok) {
+        const data = await res.json();
+        setHistory(data);
+      }
+    } catch (err) {
+      console.error('Failed to fetch spell history', err);
+    }
+  }, [limit]);
+
+  useEffect(() => {
+    fetchSpells();
+    fetchHistory();
+  }, [fetchSpells, fetchHistory]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const handler = () => fetchHistory();
+    socket.on('spellCast', handler);
+    return () => {
+      socket.off('spellCast', handler);
+    };
+  }, [socket, fetchHistory]);
+
+  const formatAddr = (addr: string) =>
+    addr.length <= 10 ? addr : `${addr.slice(0, 4)}…${addr.slice(-4)}`;
+
+  return (
+    <div className="bg-dungeon-surface/90 backdrop-blur-sm border border-dungeon-border rounded-lg p-3 shadow-lg w-56 text-sm">
+      <h3 className="text-lg font-dungeon font-bold text-dungeon-gold mb-3 flex items-center space-x-2 glow-text">
+        <Sparkles className="w-5 h-5" />
+        <span>Recent Spells</span>
+      </h3>
+      {history.length === 0 ? (
+        <div className="text-gray-400 text-center py-4 text-sm">No spells cast yet...</div>
+      ) : (
+        <div className="space-y-1 max-h-60 overflow-y-auto custom-scrollbar text-sm">
+          {history.map(entry => {
+            const meta = spells[entry.spellId];
+            const label = meta ? `${meta.emoji} ${meta.name}` : entry.spellId;
+            return (
+              <div key={entry.id} className="flex justify-between w-full px-1">
+                <span className="text-gray-200 truncate">{label}</span>
+                <span className="text-gray-400 font-mono" title={entry.wallet}>{formatAddr(entry.wallet)}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SpellHistory;


### PR DESCRIPTION
## Summary
- add new `SpellHistory` component to show recent spells
- place kill and spell history together on desktop
- expose spell history tab in mobile menu