### PR TITLE
Add recent token transfers list

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,23 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
-import { useSocket } from '@/lib/useSocket';
-import { useSolanaWallet } from '@/lib/useSolanaWallet';
-import { SolanaConnect } from '@/components/SolanaConnect';
-import PlayerStats from '@/components/PlayerStats';
-import Leaderboard from '@/components/Leaderboard';
-import MonsterComponent from '@/components/MonsterComponent';
-import SpellSelector from '@/components/SpellSelector';
-import MonsterDamageBoard from '@/components/MonsterDamageBoard';
-import TreasureBox from '@/components/TreasureBox';
-import MobileMenu from '@/components/MobileMenu';
-import MonsterKillHistory from '@/components/MonsterKillHistory';
-import SpellHistory from '@/components/SpellHistory';
-import Footer from '@/components/Footer';
-import LaunchCountdown from '@/components/LaunchCountdown';
-import { devLog } from '@/lib/devLog';
-import Image from 'next/image';
+import { useEffect, useState } from "react";
+import { useSocket } from "@/lib/useSocket";
+import { useSolanaWallet } from "@/lib/useSolanaWallet";
+import { SolanaConnect } from "@/components/SolanaConnect";
+import PlayerStats from "@/components/PlayerStats";
+import Leaderboard from "@/components/Leaderboard";
+import MonsterComponent from "@/components/MonsterComponent";
+import SpellSelector from "@/components/SpellSelector";
+import MonsterDamageBoard from "@/components/MonsterDamageBoard";
+import TreasureBox from "@/components/TreasureBox";
+import MobileMenu from "@/components/MobileMenu";
+import MonsterKillHistory from "@/components/MonsterKillHistory";
+import SpellHistory from "@/components/SpellHistory";
+import TokenTransferHistory from "@/components/TokenTransferHistory";
+import Footer from "@/components/Footer";
+import LaunchCountdown from "@/components/LaunchCountdown";
+import { devLog } from "@/lib/devLog";
+import Image from "next/image";
 
 export default function Home() {
   const launchAtStr = process.env.NEXT_PUBLIC_LAUNCH_AT;
@@ -37,15 +38,15 @@ export default function Home() {
     spellCast,
     currentMonsterId,
     attack,
-    connectWallet
+    connectWallet,
   } = useSocket();
 
-  const onlineCount = gameState?.players.filter(p => p.isOnline).length || 0;
+  const onlineCount = gameState?.players.filter((p) => p.isOnline).length || 0;
 
   const {
     connected: walletConnected,
     address: walletAddress,
-    shortAddress
+    shortAddress,
   } = useSolanaWallet();
 
   const [showSpells, setShowSpells] = useState(false);
@@ -54,32 +55,39 @@ export default function Home() {
 
   // Initial mount log
   useEffect(() => {
-    devLog('Home page mounted');
-    return () => devLog('Home page unmounted');
+    devLog("Home page mounted");
+    return () => devLog("Home page unmounted");
   }, []);
 
   // Wallet connection log
   useEffect(() => {
-    devLog('Wallet connection status changed', { walletConnected, walletAddress });
+    devLog("Wallet connection status changed", {
+      walletConnected,
+      walletAddress,
+    });
     if (walletConnected && walletAddress) {
-      devLog('Wallet connected, registering player', { walletAddress });
+      devLog("Wallet connected, registering player", { walletAddress });
       connectWallet(walletAddress);
     }
   }, [walletConnected, walletAddress, connectWallet]);
 
   // Socket connection log
   useEffect(() => {
-    devLog('Socket connection status', { isConnected, connectionError });
+    devLog("Socket connection status", { isConnected, connectionError });
   }, [isConnected, connectionError]);
 
   // Game state or registration change log
   useEffect(() => {
-    devLog('Game state or registration status changed', { isRegistered, gameState });
+    devLog("Game state or registration status changed", {
+      isRegistered,
+      gameState,
+    });
   }, [isRegistered, gameState]);
 
   // Fetch rewards for the current monster
   useEffect(() => {
-    const SOCKET_URL = process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3001';
+    const SOCKET_URL =
+      process.env.NEXT_PUBLIC_SOCKET_URL || "http://localhost:3001";
     let mounted = true;
     const loadRewards = async () => {
       try {
@@ -90,7 +98,7 @@ export default function Home() {
           setLootTokens(Math.round(data.tokenPool));
         }
       } catch (err) {
-        console.error('Failed to fetch rewards', err);
+        console.error("Failed to fetch rewards", err);
       }
     };
     loadRewards();
@@ -103,7 +111,7 @@ export default function Home() {
 
   // Loading screen
   if (!isConnected && !connectionError) {
-    devLog('Rendering: loading screen, not connected yet');
+    devLog("Rendering: loading screen, not connected yet");
     return (
       <div className="min-h-screen bg-dungeon-bg dungeon-atmosphere flex items-center justify-center">
         <div className="text-center">
@@ -140,7 +148,7 @@ export default function Home() {
 
   // Connection error screen
   if (connectionError) {
-    devLog('Rendering: connection error screen', { connectionError });
+    devLog("Rendering: connection error screen", { connectionError });
     return (
       <div className="min-h-screen bg-dungeon-bg dungeon-atmosphere flex items-center justify-center">
         <div className="text-center max-w-md">
@@ -153,7 +161,7 @@ export default function Home() {
           </div>
           <button
             onClick={() => {
-              devLog('User clicked Try Again (reload)');
+              devLog("User clicked Try Again (reload)");
               window.location.reload();
             }}
             className="bg-dungeon-primary hover:bg-dungeon-secondary text-white font-bold py-3 px-6 rounded-lg transition-colors duration-200 border border-dungeon-border"
@@ -172,7 +180,7 @@ export default function Home() {
 
   // Wallet connection required screen
   if (!walletConnected) {
-    devLog('Rendering: wallet connection required screen');
+    devLog("Rendering: wallet connection required screen");
     return (
       <div className="min-h-screen bg-dungeon-bg dungeon-atmosphere flex items-center justify-center">
         <div className="absolute top-4 right-4 z-50">
@@ -194,7 +202,9 @@ export default function Home() {
             <h1 className="text-3xl font-dungeon font-bold text-dungeon-gold mb-2 glow-text">
               THE DUNGEON
             </h1>
-            <p className="text-gray-300 mb-4">Connect your Solana wallet to enter</p>
+            <p className="text-gray-300 mb-4">
+              Connect your Solana wallet to enter
+            </p>
             <p className="text-sm text-gray-400">
               Your wallet address will be your warrior identity
             </p>
@@ -214,20 +224,25 @@ export default function Home() {
 
   // Game loading or registration in progress
   if (!gameState || !isRegistered) {
-    devLog('Rendering: game loading or registration screen', { gameState, isRegistered, playerStats });
+    devLog("Rendering: game loading or registration screen", {
+      gameState,
+      isRegistered,
+      playerStats,
+    });
     return (
       <div className="min-h-screen bg-dungeon-bg dungeon-atmosphere flex items-center justify-center">
         <div className="text-center">
           <div className="text-5xl mb-4 animate-pulse">🎮</div>
           <div className="text-xl text-white mb-2">
-            {!isRegistered ? 'Registering warrior...' : 'Loading game...'}
+            {!isRegistered ? "Registering warrior..." : "Loading game..."}
           </div>
           <div className="text-sm text-gray-400 mt-2">
             Warrior: {shortAddress}
           </div>
           {playerStats && (
             <div className="text-sm text-green-400 mt-2">
-              Level {playerStats.level} • {playerStats.totalDamage.toLocaleString()} total damage
+              Level {playerStats.level} •{" "}
+              {playerStats.totalDamage.toLocaleString()} total damage
             </div>
           )}
         </div>
@@ -244,12 +259,14 @@ export default function Home() {
   const bossDamageEntries = Object.entries(bossDamage)
     .map(([wallet, dmg]) => ({
       walletAddress: wallet,
-      name: gameState.players.find(p => p.walletAddress === wallet)?.name ?? '???',
+      name:
+        gameState.players.find((p) => p.walletAddress === wallet)?.name ??
+        "???",
       damage: dmg,
     }))
     .sort((a, b) => b.damage - a.damage);
 
-  devLog('Rendering: main game screen', {
+  devLog("Rendering: main game screen", {
     playerStats,
     walletAddress,
     bossDamageEntries,
@@ -258,13 +275,12 @@ export default function Home() {
   });
 
   // Players list formatted for leaderboard components
-  const leaderboardPlayers = gameState.players.map(p => ({
+  const leaderboardPlayers = gameState.players.map((p) => ({
     walletAddress: p.walletAddress,
     name: p.name,
     totalDamage: (p as any).totalDamage ?? p.damage,
     isOnline: p.isOnline,
   }));
-
 
   // Main game screen
   return (
@@ -293,6 +309,7 @@ export default function Home() {
       <div className="hidden md:block absolute top-20 right-4 z-40 space-y-4">
         <MonsterKillHistory />
         <SpellHistory />
+        <TokenTransferHistory />
       </div>
 
       {/* Desktop layout */}
@@ -318,7 +335,7 @@ export default function Home() {
           spellCast={spellCast}
           onFirstAttack={() => setShowSpells(true)}
           onAttack={(...params) => {
-            devLog('Attack triggered from UI', params);
+            devLog("Attack triggered from UI", params);
             attack(...params);
           }}
         />

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -1,15 +1,25 @@
-'use client';
+"use client";
 
-import { FC, useState } from 'react';
-import { X, Menu, BarChart3, Users, Sword, PackageOpen, Skull, Sparkles } from 'lucide-react';
-import PlayerStats from './PlayerStats';
-import Leaderboard from './Leaderboard';
-import MonsterDamageBoard from './MonsterDamageBoard';
-import TreasureBox from './TreasureBox';
-import MonsterKillHistory from './MonsterKillHistory';
-import SpellHistory from './SpellHistory';
+import { FC, useState } from "react";
+import {
+  X,
+  Menu,
+  BarChart3,
+  Users,
+  Sword,
+  PackageOpen,
+  Skull,
+  Sparkles,
+  Coins,
+} from "lucide-react";
+import PlayerStats from "./PlayerStats";
+import Leaderboard from "./Leaderboard";
+import MonsterDamageBoard from "./MonsterDamageBoard";
+import TreasureBox from "./TreasureBox";
+import MonsterKillHistory from "./MonsterKillHistory";
+import SpellHistory from "./SpellHistory";
+import TokenTransferHistory from "./TokenTransferHistory";
 import Image from "next/image";
-
 
 interface PlayerData {
   walletAddress: string;
@@ -49,20 +59,29 @@ const MobileMenu: FC<MobileMenuProps> = ({
   bossDamageEntries,
   selfWallet,
   xp,
-  tokens
+  tokens,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState<'stats' | 'leaderboard' | 'damage' | 'loot' | 'history' | 'spells'>('stats');
+  const [activeTab, setActiveTab] = useState<
+    | "stats"
+    | "leaderboard"
+    | "damage"
+    | "loot"
+    | "history"
+    | "spells"
+    | "airdrops"
+  >("stats");
 
   const toggleMenu = () => setIsOpen(!isOpen);
 
   const tabs = [
-    { id: 'stats' as const, label: 'Stats', icon: BarChart3 },
-    { id: 'leaderboard' as const, label: 'Ranking', icon: Users },
-    { id: 'damage' as const, label: 'Boss DMG', icon: Sword },
-    { id: 'loot' as const, label: 'Loot', icon: PackageOpen },
-    { id: 'history' as const, label: 'Kills', icon: Skull },
-    { id: 'spells' as const, label: 'Spells', icon: Sparkles },
+    { id: "stats" as const, label: "Stats", icon: BarChart3 },
+    { id: "leaderboard" as const, label: "Ranking", icon: Users },
+    { id: "damage" as const, label: "Boss DMG", icon: Sword },
+    { id: "loot" as const, label: "Loot", icon: PackageOpen },
+    { id: "history" as const, label: "Kills", icon: Skull },
+    { id: "spells" as const, label: "Spells", icon: Sparkles },
+    { id: "airdrops" as const, label: "Airdrops", icon: Coins },
   ];
 
   return (
@@ -90,8 +109,9 @@ const MobileMenu: FC<MobileMenuProps> = ({
 
       {/* Side Menu */}
       <div
-        className={`md:hidden fixed top-0 left-0 h-full w-80 max-w-[85vw] bg-dungeon-surface/95 backdrop-blur-md border-r border-dungeon-border shadow-2xl z-50 transform transition-transform duration-300 ease-in-out ${isOpen ? 'translate-x-0' : '-translate-x-full'
-          }`}
+        className={`md:hidden fixed top-0 left-0 h-full w-80 max-w-[85vw] bg-dungeon-surface/95 backdrop-blur-md border-r border-dungeon-border shadow-2xl z-50 transform transition-transform duration-300 ease-in-out ${
+          isOpen ? "translate-x-0" : "-translate-x-full"
+        }`}
       >
         {/* Menu Header */}
         <div className="flex items-center justify-between p-4 border-b border-dungeon-border">
@@ -114,10 +134,11 @@ const MobileMenu: FC<MobileMenuProps> = ({
               <button
                 key={tab.id}
                 onClick={() => setActiveTab(tab.id)}
-                className={`flex-1 flex items-center justify-center space-x-2 py-3 px-2 text-sm font-medium transition-colors ${activeTab === tab.id
-                    ? 'text-dungeon-gold border-b-2 border-dungeon-gold bg-dungeon-accent/30'
-                    : 'text-gray-400 hover:text-white hover:bg-dungeon-accent/20'
-                  }`}
+                className={`flex-1 flex items-center justify-center space-x-2 py-3 px-2 text-sm font-medium transition-colors ${
+                  activeTab === tab.id
+                    ? "text-dungeon-gold border-b-2 border-dungeon-gold bg-dungeon-accent/30"
+                    : "text-gray-400 hover:text-white hover:bg-dungeon-accent/20"
+                }`}
               >
                 <Icon className="w-4 h-4" />
                 <span className="hidden sm:inline">{tab.label}</span>
@@ -128,19 +149,19 @@ const MobileMenu: FC<MobileMenuProps> = ({
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto p-4">
-          {activeTab === 'stats' && (
+          {activeTab === "stats" && (
             <div className="space-y-4">
               <PlayerStats player={playerStats} />
             </div>
           )}
 
-          {activeTab === 'leaderboard' && (
+          {activeTab === "leaderboard" && (
             <div className="space-y-4">
               <Leaderboard players={players} selfWallet={selfWallet} />
             </div>
           )}
 
-          {activeTab === 'damage' && (
+          {activeTab === "damage" && (
             <div className="space-y-4">
               <MonsterDamageBoard
                 entries={bossDamageEntries}
@@ -149,21 +170,27 @@ const MobileMenu: FC<MobileMenuProps> = ({
             </div>
           )}
 
-          {activeTab === 'loot' && (
+          {activeTab === "loot" && (
             <div className="space-y-4">
               <TreasureBox xp={xp} tokens={tokens} />
             </div>
           )}
 
-          {activeTab === 'history' && (
+          {activeTab === "history" && (
             <div className="space-y-4">
               <MonsterKillHistory />
             </div>
           )}
 
-          {activeTab === 'spells' && (
+          {activeTab === "spells" && (
             <div className="space-y-4">
               <SpellHistory />
+            </div>
+          )}
+
+          {activeTab === "airdrops" && (
+            <div className="space-y-4">
+              <TokenTransferHistory />
             </div>
           )}
         </div>

--- a/src/components/TokenTransferHistory.tsx
+++ b/src/components/TokenTransferHistory.tsx
@@ -48,7 +48,7 @@ const TokenTransferHistory: FC<TokenTransferHistoryProps> = ({ limit = 5 }) => {
     <div className="bg-dungeon-surface/90 backdrop-blur-sm border border-dungeon-border rounded-lg p-3 shadow-lg w-56 text-sm">
       <h3 className="text-lg font-dungeon font-bold text-dungeon-gold mb-3 flex items-center space-x-2 glow-text">
         <Coins className="w-5 h-5" />
-        <span>Recent Tokens</span>
+        <span>Recent Airdrops</span>
       </h3>
       {transfers.length === 0 ? (
         <div className="text-gray-400 text-center py-4 text-sm">

--- a/src/components/TokenTransferHistory.tsx
+++ b/src/components/TokenTransferHistory.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { FC, useCallback, useEffect, useState } from "react";
+import { Coins } from "lucide-react";
+
+const SOCKET_URL =
+  process.env.NEXT_PUBLIC_SOCKET_URL || "http://localhost:3001";
+
+interface TokenTransfer {
+  id: number;
+  wallet: string;
+  amount: number;
+  txId: string;
+  createdAt: string;
+}
+
+interface TokenTransferHistoryProps {
+  limit?: number;
+}
+
+const TokenTransferHistory: FC<TokenTransferHistoryProps> = ({ limit = 5 }) => {
+  const [transfers, setTransfers] = useState<TokenTransfer[]>([]);
+
+  const fetchTransfers = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `${SOCKET_URL}/api/game/token-transfers?limit=${limit}`,
+      );
+      if (res.ok) {
+        const data = await res.json();
+        setTransfers(data);
+      }
+    } catch (err) {
+      console.error("Failed to fetch token transfers", err);
+    }
+  }, [limit]);
+
+  useEffect(() => {
+    fetchTransfers();
+    const id = setInterval(fetchTransfers, 10000);
+    return () => clearInterval(id);
+  }, [fetchTransfers]);
+
+  const formatAddr = (addr: string) =>
+    addr.length <= 10 ? addr : `${addr.slice(0, 4)}…${addr.slice(-4)}`;
+
+  return (
+    <div className="bg-dungeon-surface/90 backdrop-blur-sm border border-dungeon-border rounded-lg p-3 shadow-lg w-56 text-sm">
+      <h3 className="text-lg font-dungeon font-bold text-dungeon-gold mb-3 flex items-center space-x-2 glow-text">
+        <Coins className="w-5 h-5" />
+        <span>Recent Tokens</span>
+      </h3>
+      {transfers.length === 0 ? (
+        <div className="text-gray-400 text-center py-4 text-sm">
+          No token transfers yet...
+        </div>
+      ) : (
+        <div className="space-y-1 max-h-60 overflow-y-auto custom-scrollbar text-sm">
+          {transfers.map((t) => (
+            <div key={t.id} className="flex justify-between w-full px-1">
+              <span className="text-gray-200 truncate">+{t.amount}</span>
+              <span className="text-gray-400 font-mono" title={t.wallet}>
+                {formatAddr(t.wallet)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TokenTransferHistory;


### PR DESCRIPTION
## Summary
- show recent token transfers from API
- add airdrops tab in mobile menu
- display token transfers on desktop sidebar

## Testing
- `npm install`
- `npx prettier -w src/components/TokenTransferHistory.tsx src/components/MobileMenu.tsx src/app/page.tsx`
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_684c8928c6b883238fc53865b45707fa