### PR TITLE
Shrink mobile wallet connector

### DIFF
--- a/src/styles/wallet.css
+++ b/src/styles/wallet.css
@@ -80,3 +80,11 @@
 .wallet-adapter-modal-button-close:hover {
   color: #ffd600 !important;
 }
+
+@media (max-width: 480px) {
+  .wallet-btn,
+  .wallet-adapter-button {
+    padding: 0.35rem 0.9rem !important;
+    font-size: 0.85rem !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive CSS to shrink Solana wallet button on small screens

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_684cbc8e031083239c1f85c44c38683a